### PR TITLE
Correct main class name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 }
 
 // Define the main class for the application.
-mainClassName = 'matilda2.AppKt'
+mainClassName = 'matilda2.Launcher'
 run {
     args = ['server', 'config.yml']
 }


### PR DESCRIPTION
As the main function was placed inside the `Launcher` object it is no
longer possible to build the module with Gradle.

@rattmuffen, could you please have a look at this?